### PR TITLE
More precise way to hide the noisy types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 # Tell Git Linguist to ignore Swagger content files when deciding what language
 # is used in the repository
 ###############################################################################
-Swagger/** linguist-generated=true
+Swagger/** linguist-documentation=true

--- a/Swagger/index.html
+++ b/Swagger/index.html
@@ -57,8 +57,21 @@
 
       .json-schema-2020-12-keyword__value--const
       {
+        /* Same style as json-schema-2020-12__constraint (used for ranges) */
         background-color: #805ad5;
         color: #fff!important;
+      }
+
+      .json-schema-2020-12__attribute--primary
+      {
+        /* Same style as json-schema-2020-12__constraint--string (used for `format`) */
+        background-color: #d69e2e;
+        color: #fff!important;
+        border-radius: 4px;
+        padding: 1px 3px !important;
+        margin-left: 10px;
+        line-height: 1.5;
+        font-size: inherit !important;
       }
     </style>
   </head>

--- a/Swagger/index.html
+++ b/Swagger/index.html
@@ -13,6 +13,7 @@
     <!-- .base-url - Remove the Swagger file url -->
     <!-- .swagger-ui .info hgroup.main a - Remove the Swagger file description -->
     <!-- .json-schema-2020-12-keyword__value--const - Make constant values have same style as range constraints. -->
+    <!-- .json-schema-2020-12__attribute--primary - Make `type` and `format` attributes look the same. -->
     <style>
       html
       {

--- a/Swagger/index.html
+++ b/Swagger/index.html
@@ -56,11 +56,6 @@
         display:none!important;
       }
 
-      .json-schema-2020-12__attribute--primary
-      {
-        display: none;
-      }
-
       .json-schema-2020-12-keyword__value--const
       {
         background-color: #805ad5;
@@ -78,24 +73,43 @@
       // Custom plugin to add ASCOM logo and text to the top bar
       const ASCOMLogo = {
         components: {
-          Logo: () => {
-            const { createElement, Fragment } = ui.React;
+          Logo: () => createElement(
+            Fragment,
+            null,
+            createElement('img', {
+              src: 'bugt300square.jpg',
+              alt: 'ASCOM logo',
+              width: 70,
+              height: 70
+            }),
+            createElement(
+              'span',
+              { style: { fontSize: '18px' } },
+              'ASCOM Initiative'
+            )
+          )
+        }
+      };
 
-            return createElement(
-              Fragment,
-              null,
-              createElement('img', {
-                src: 'bugt300square.jpg',
-                alt: 'ASCOM logo',
-                width: 70,
-                height: 70
-              }),
-              createElement(
-                'span',
-                { style: { fontSize: '18px' } },
-                'ASCOM Initiative'
-              )
-            );
+      const HIDE_TYPE_IF = [
+        // Don't show the noisy type `integer | integer | integer | ...` for `oneOf` variants as parent will already show the shared type.
+        'oneOf',
+        // Don't show the type if a more precise `format` is already available.
+        'format',
+        // Don't show the type if it's obviously an integer with a range constraint.
+        'minimum',
+        'maximum',
+        'const',
+      ];
+
+      const CleanupTypes = {
+        wrapComponents: {
+          JSONSchema202012KeywordType: (OriginalComponent, system) => props => {
+            if (HIDE_TYPE_IF.some(keyword => keyword in props.schema)) {
+              return null;
+            }
+            // Otherwise use the default formatter.
+            return createElement(OriginalComponent, props);
           }
         }
       };
@@ -116,10 +130,13 @@
         ],
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl,
-          ASCOMLogo
+          ASCOMLogo,
+          CleanupTypes,
         ],
         layout: "StandaloneLayout"
       });
+
+      const { createElement, Fragment } = ui.React;
     </script>
   </body>
 </html>

--- a/Swagger/index.html
+++ b/Swagger/index.html
@@ -14,6 +14,7 @@
     <!-- .swagger-ui .info hgroup.main a - Remove the Swagger file description -->
     <!-- .json-schema-2020-12-keyword__value--const - Make constant values have same style as range constraints. -->
     <!-- .json-schema-2020-12__attribute--primary - Make `type` and `format` attributes look the same. -->
+    <!-- .response-col_links - Hide the "links" column in the response tables as we don't use that OpenAPI feature and it's always empty. -->
     <style>
       html
       {
@@ -73,6 +74,11 @@
         margin-left: 10px;
         line-height: 1.5;
         font-size: inherit !important;
+      }
+
+      .response-col_links
+      {
+        display:none;
       }
     </style>
   </head>

--- a/Swagger/index.html
+++ b/Swagger/index.html
@@ -12,7 +12,6 @@
     <!-- .select-label - Change the select an API text to white -->
     <!-- .base-url - Remove the Swagger file url -->
     <!-- .swagger-ui .info hgroup.main a - Remove the Swagger file description -->
-    <!-- .json-schema-2020-12__attribute--primary - Hide the OpenAPI type (e.g. `integer | integer | ...`) as we already show a more precise custom format (e.g. `int32`). -->
     <!-- .json-schema-2020-12-keyword__value--const - Make constant values have same style as range constraints. -->
     <style>
       html


### PR DESCRIPTION
Fixup for the last-minute issue introduced and mentioned in https://github.com/ASCOMInitiative/ASCOMRemote/pull/58#issuecomment-2315012491

![image](https://github.com/user-attachments/assets/cf1e6af1-b58a-46d6-bf4d-0d7177b1f9a0)

`integer | integer | ...` are still hidden where they don't add any new information, but `string` and other types are fixed and shown again.