### PR TITLE
Clarify exposure start timezone

### DIFF
--- a/Swagger/AlpacaDeviceAPI_v1.yaml
+++ b/Swagger/AlpacaDeviceAPI_v1.yaml
@@ -1371,7 +1371,7 @@ paths:
       summary: Start time of the last exposure in FITS standard format.
       description: >-
         Reports the actual exposure start in the FITS-standard
-        CCYY-MM-DDThh:mm:ss[.sss...] format.
+        CCYY-MM-DDThh:mm:ss[.sss...] format. The time must be UTC.
       parameters:
         - $ref: '#/components/parameters/device_number'
         - $ref: '#/components/parameters/ClientIDQuery'


### PR DESCRIPTION
This wasn't clear to me immediately, because, unlike telescope time, this one doesn't have the timezone offset (`Z`) and I was wondering if it could be camera's own timezone instead.

Eventually I found the answer in the ASCOM docs, and figured it would be useful to replicate clarification here.