### PR TITLE
Add OpenAPI deprecation annotations

### DIFF
--- a/Swagger/AlpacaDeviceAPI_v1.yaml
+++ b/Swagger/AlpacaDeviceAPI_v1.yaml
@@ -146,6 +146,7 @@ paths:
                     - Action
                     - Parameters
   '/{device_type}/{device_number}/commandblind':
+    deprecated: true
     put:
       summary: Transmits an arbitrary string to the device
       description: >-
@@ -168,6 +169,7 @@ paths:
         $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandblind'
   '/{device_type}/{device_number}/commandbool':
     put:
+      deprecated: true
       summary: >-
         Transmits an arbitrary string to the device and returns a boolean value
         from the device.
@@ -190,6 +192,7 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandblind'
   '/{device_type}/{device_number}/commandstring':
+    deprecated: true
     put:
       summary: >-
         Transmits an arbitrary string to the device and returns a string value
@@ -249,8 +252,12 @@ paths:
         '500':
           $ref: '#/components/responses/500'
     put:
+      deprecated: true
       summary: Sets the connected state of the device
-      description: Sets the connected state of the device
+      description: >-
+        **Deprecated in favour of the newer non-blocking [`connect`](#/ASCOM%20Methods%20Common%20To%20All%20Devices/put__device_type___device_number__connect) and [`disconnect`](#/ASCOM%20Methods%20Common%20To%20All%20Devices/put__device_type___device_number__disconnect) methods, with the new [`connecting`](#/ASCOM%20Methods%20Common%20To%20All%20Devices/get__device_type___device_number__connecting) property serving as the completion property.**  
+          
+        Sets the connected state of the device
       tags:
         - ASCOM Methods Common To All Devices
       parameters:
@@ -1203,8 +1210,19 @@ paths:
           $ref: '#/components/responses/500'
   '/camera/{device_number}/imagearrayvariant':
     get:
+      deprecated: true
       summary: Returns an array of numbers containing the exposure pixel values
       description: >
+        **This method is deprecated in favour of [`imagearray`](#/Camera%20Specific%20Methods/get_camera__device_number__imagearray).**
+          
+        The ImageArrayVariant property is a functional duplicate of the ImageArray 
+        property but returns data using the variant type, which requires more memory and processor 
+        resource than the Int32 type returned by ImageArray.
+
+        ImageArrayVariant was included in the ASCOM interface to support scripting languages that 
+        required data elements to be of variant type rather than as integer type. However, this restriction no 
+        longer applies and the ImageArrayVariant property is now redundant.
+
         Returns an array containing the pixel values from the last exposure.
         This call can return either a 2 dimension (monochrome images) or a 3
         dimension (colour or multi-plane images) array of size `NumX * NumY` or
@@ -5596,8 +5614,11 @@ paths:
         $ref: '#/components/requestBodies/putStandardClientParameters'
   '/telescope/{device_number}/slewtoaltaz':
     put:
+      deprecated: true
       summary: Synchronously slew to the given local horizontal coordinates.
       description: >-
+        **This method is deprecated in favour of [`slewtoaltazasync`](#/Telescope%20Specific%20Methods/put_telescope__device_number__slewtoaltazasync).**
+          
         Move the telescope to the given local horizontal coordinates, return
         when slew is complete
       parameters:
@@ -5635,8 +5656,11 @@ paths:
         $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtoaltaz'
   '/telescope/{device_number}/slewtocoordinates':
     put:
+      deprecated: true
       summary: Synchronously slew to the given equatorial coordinates.
       description: >-
+        **This method is deprecated in favour of [`slewtocoordinatesasync`](#/Telescope%20Specific%20Methods/put_telescope__device_number__slewtocoordinatesasync).**
+          
         Move the telescope to the given equatorial coordinates, return when slew
         is complete
       parameters:
@@ -5674,10 +5698,13 @@ paths:
         $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtocoordinates'
   '/telescope/{device_number}/slewtotarget':
     put:
+      deprecated: true
       summary: >-
         Synchronously slew to the TargetRightAscension and TargetDeclination
         coordinates.
       description: >-
+        **This method is deprecated in favour of [`slewtotargetasync`](#/Telescope%20Specific%20Methods/put_telescope__device_number__slewtotargetasync).**
+          
         Move the telescope to the TargetRightAscension and TargetDeclination
         equatorial coordinates, return when slew is complete
       parameters:


### PR DESCRIPTION
This mirrors deprecation warnings from ASCOM docs to OpenAPI annotations, with custom description where necessary.