### PR TITLE
Add CI validation & fix issue

### DIFF
--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+  validate_openapi:
+    runs-on: ubuntu-latest
+    name: Validate OpenAPI definitions
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OpenAPI validator
+        run: npm install -g @redocly/cli
+      - name: Validate definitions
+        run: redocly lint Swagger/*.yaml
+        env:
+          NODE_NO_WARNINGS: 1

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,6 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redoc.ly/docs/cli/ for more information.
+Swagger/AlpacaManagementAPI_v1.yaml:
+  # /setup endpoint must always be present
+  operation-4xx-response:
+    - '#/paths/~1setup/get/responses'

--- a/Swagger/AlpacaDeviceAPI_v1.yaml
+++ b/Swagger/AlpacaDeviceAPI_v1.yaml
@@ -146,8 +146,8 @@ paths:
                     - Action
                     - Parameters
   '/{device_type}/{device_number}/commandblind':
-    deprecated: true
     put:
+      deprecated: true
       summary: Transmits an arbitrary string to the device
       description: >-
         Transmits an arbitrary string to the device and does not wait for a
@@ -192,8 +192,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandblind'
   '/{device_type}/{device_number}/commandstring':
-    deprecated: true
     put:
+      deprecated: true
       summary: >-
         Transmits an arbitrary string to the device and returns a string value
         from the device.

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,6 @@
+extends:
+  - recommended
+rules:
+  security-defined: off
+  operation-operationId: off
+  info-license: off


### PR DESCRIPTION
After submitting the previous PR, I accidentally noticed that I misplaced two of the `deprecated` field usages.

Since similar silly mistakes happened couple of times now, I decided to take some time and add OpenAPI schema validation step to the CI. After trying with several linters on my personal fork, this one seems most promising and configurable, so adding it here.